### PR TITLE
Change db host/port to rethinkdb defaults

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -1,7 +1,7 @@
 // RethinkDB database settings
 var dbConfig = {
-  'host': '192.168.0.7',
-  'port': 38015,
+  'host': 'localhost',
+  'port': 28015,
   'db'  : 'chat',
   'tables': {
     'messages': 'id',


### PR DESCRIPTION
Really cool example app! Thanks for putting it together. I tried running it after I got rethinkdb installed, and it worked until the app needed to hit the database, at which point it crashed. Took me a second to realize I needed to switch db settings in /lib to the defaults of rethinkdb. For an example app, seems like a good idea to adhere to the host/port settings rethinkdb has out of the box.

Hope this is helpful feedback!
