### PR TITLE
Freeze dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   "dependencies": {
     "express": "3.4.7",
     "jade": "1.0.0",
-    "rethinkdb": "1.12.0",
+    "rethinkdb": "1.12.0-0",
     "passport": "0.1.17",
-    "passport-local": "0.1.17",
+    "passport-local": "0.1.6",
     "bcrypt": "0.7.7",
     "socket.io": "0.9.16",
     "connect-flash": "0.1.1",


### PR DESCRIPTION
Ping @coffeemug -- can you take a quick look?
It fixes https://github.com/rethinkdb/rethinkdb-example-nodejs-chat/issues/7

Express 4 changed its API, and configure is not available anymore.
