### PR TITLE
Addressing potential connection leaks

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -86,10 +86,12 @@ module.exports.findUserByEmail = function (mail, callback) {
     r.db(dbConfig.db).table('users').filter({'mail': mail}).limit(1).run(connection, function(err, cursor) {
       if(err) {
         logerror("[ERROR][%s][findUserByEmail][collect] %s:%s\n%s", connection['_id'], err.name, err.msg, err.message);
+        connection.close();
         callback(err);
       }
       else {
         cursor.next(function (err, row) {
+          connection.close();
           if(err) {
             logerror("[ERROR][%s][findUserByEmail][collect] %s:%s\n%s", connection['_id'], err.name, err.msg, err.message);
             callback(err);
@@ -97,7 +99,6 @@ module.exports.findUserByEmail = function (mail, callback) {
           else {
             callback(null, row);
           }
-          connection.close();
         });
       }
 


### PR DESCRIPTION
Addressing potential **connection leak** issues caused by connections not being `close()`'ed properly inside a `run` handler function. For instance: if an error is thrown or the callback function screws up, the connection object would then be left opened till who-knows-how-long.

I'm not entirely sure if my hypothesis is correct though, so please fix me if I'm wrong. Thank you!